### PR TITLE
Add conditional return for latency list in GenerationMixin

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2403,7 +2403,10 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result, latency_list
+        if self.config.no_token_latency:
+            return result
+        else:
+            return result, latency_list
 
     def _has_unfinished_sequences(
         self,


### PR DESCRIPTION
Since we use lm_eval for the accuracy tests of MMLU and GSM8K, we need to disable token latency output to ensure compatibility with lm_eval during the accuracy tests.
https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/pull/3850